### PR TITLE
Updated layer2 drop in script to set/unset cookies

### DIFF
--- a/packages/members/layer1/index.js
+++ b/packages/members/layer1/index.js
@@ -1,24 +1,24 @@
-const jwt = require('jsonwebtoken');
-const store = window.localStorage;
+var jwt = require('jsonwebtoken');
+var store = window.localStorage;
 
-const create = (options) => {
+function create(options) {
     return {
-        getToken() {
-            let token = store.getItem('members-token') || null;
+        getToken: function getToken() {
+            var token = store.getItem('members-token') || null;
             return Promise.resolve(token);
         },
 
-        login() {
-            let token = jwt.sign({}, null, {algorithm: 'none'});
+        login: function login() {
+            var token = jwt.sign({}, null, {algorithm: 'none'});
             store.setItem('members-token', token);
             return Promise.resolve(!!token);
         },
 
-        logout() {
+        logout: function logout() {
             store.removeItem('members-token');
             return Promise.resolve(true);
         }
-    }
-};
+    };
+}
 
 module.exports.create = create;

--- a/packages/members/layer2/drop-in.js
+++ b/packages/members/layer2/drop-in.js
@@ -2,5 +2,3 @@ const Members = require('./');
 const ready = require('document-ready');
 
 ready(Members.init);
-
-module.exports = Members;

--- a/packages/members/layer2/drop-in.js
+++ b/packages/members/layer2/drop-in.js
@@ -1,4 +1,4 @@
-const Members = require('./');
-const ready = require('document-ready');
+var Members = require('./');
+var ready = require('document-ready');
 
 ready(Members.init);

--- a/packages/members/layer2/index.js
+++ b/packages/members/layer2/index.js
@@ -1,26 +1,33 @@
-const Members = require('@tryghost/members-layer1');
+var Members = require('@tryghost/members-layer1');
 
-const members = Members.create();
+var members = Members.create();
 
-const show = el => el.style.display = 'block';
-const hide = el => el.style.display = 'none';
-const reload = () => location.reload();
+function show (el) {
+    el.style.display = 'block';
+}
+function hide (el) {
+    el.style.display = 'none';
+}
 
-const setCookie = (token) => {
+function reload() {
+    location.reload();
+}
+
+function setCookie(token) {
     if (!token) {
         document.cookie = 'member=null;path=/;samesite;max-age=0';
     } else {
-        document.cookie = `member=${token};path=/;samesite;`;
+        document.cookie = ['member=', token, ';path=/;samesite;'].join('');
     }
     return token;
-};
+}
 
 module.exports = {
-    init() {
-        const signin = document.querySelector('[data-members-signin]');
-        const signout = document.querySelector('[data-members-signout]');
+    init: function init() {
+        var signin = document.querySelector('[data-members-signin]');
+        var signout = document.querySelector('[data-members-signout]');
 
-        const render = (token) => {
+        function render (token) {
             if (token) {
                 show(signout);
                 hide(signin);
@@ -29,9 +36,9 @@ module.exports = {
                 hide(signout);
             }
             return token;
-        };
+        }
 
-        signin.addEventListener('click', (event) => {
+        signin.addEventListener('click', function (event) {
             event.preventDefault();
             members.login()
                 .then(members.getToken)
@@ -39,7 +46,7 @@ module.exports = {
                 .then(reload);
         });
 
-        signout.addEventListener('click', (event) => {
+        signout.addEventListener('click', function (event) {
             event.preventDefault();
             members.logout()
                 .then(members.getToken)

--- a/packages/members/layer2/index.js
+++ b/packages/members/layer2/index.js
@@ -4,42 +4,51 @@ const members = Members.create();
 
 const show = el => el.style.display = 'block';
 const hide = el => el.style.display = 'none';
+const reload = () => location.reload();
+
+const setCookie = (token) => {
+    if (!token) {
+        document.cookie = 'member=null;path=/;samesite;max-age=0';
+    } else {
+        document.cookie = `member=${token};path=/;samesite;`;
+    }
+    return token;
+};
 
 module.exports = {
-    getToken() {
-        return members.getToken();
-    },
     init() {
         const signin = document.querySelector('[data-members-signin]');
         const signout = document.querySelector('[data-members-signout]');
 
-        const render = (signedIn) => {
-            const promise = signedIn !== undefined ? Promise.resolve(signedIn) : members.getToken();
-            return promise.then((token) => {
-                if (token) {
-                    show(signout);
-                    hide(signin);
-                } else {
-                    show(signin);
-                    hide(signout);
-                }
-            });
+        const render = (token) => {
+            if (token) {
+                show(signout);
+                hide(signin);
+            } else {
+                show(signin);
+                hide(signout);
+            }
+            return token;
         };
 
         signin.addEventListener('click', (event) => {
             event.preventDefault();
             members.login()
-                .then(render);
+                .then(members.getToken)
+                .then(setCookie)
+                .then(reload);
         });
 
         signout.addEventListener('click', (event) => {
             event.preventDefault();
             members.logout()
-                .then((success) => {
-                    render(!success);
-                });
+                .then(members.getToken)
+                .then(setCookie)
+                .then(reload);
         });
 
-        return render();
+        return members.getToken()
+            .then(setCookie)
+            .then(render);
     }
 };

--- a/packages/members/layer2/package.json
+++ b/packages/members/layer2/package.json
@@ -9,8 +9,8 @@
     "dev": "echo \"Implement me!\"",
     "test": "NODE_ENV=testing mocha './test/**/*.test.js'",
     "lint": "eslint . --ext .js --cache",
-    "build:lib": "browserify -t varify -t es6ify -s Members index.js > build/members-layer2.lib.js",
-    "build:drop-in": "browserify -t varify -t es6ify -s Members drop-in.js > build/members-layer2.dropin.js",
+    "build:lib": "browserify -s Members index.js > build/members-layer2.lib.js",
+    "build:drop-in": "browserify drop-in.js > build/members-layer2.dropin.js",
     "prebuild": "rm -rf build && mkdir build",
     "build": "npm run build:lib && npm run build:drop-in",
     "posttest": "yarn lint"
@@ -20,12 +20,10 @@
   },
   "devDependencies": {
     "browserify": "^16.2.3",
-    "es6ify": "^1.6.0",
     "eslint": "^5.9.0",
     "mocha": "5.2.0",
     "should": "13.2.3",
-    "sinon": "7.1.1",
-    "varify": "^0.2.0"
+    "sinon": "7.1.1"
   },
   "dependencies": {
     "@tryghost/members-layer1": "file:../layer1",


### PR DESCRIPTION
Trying to think of how a "dropin" script should work - setting a cookie seems to make quite a bit of sense.

It would allow the server to render content based on a token (if desired)
It would also allow a user to use a separate script to `fetch` data, and send the cookie to authenticate the request.


e.g.

### usage

```html
<html>
  <head>
    <script src="members-dropin.js"></script>
    <script src="my-coole-script"></script>
  </head>
  <body>
    <button data-members-signin> Sign me in!!! </button>
    <a href="#" data-members-signout> Get me outta here </a>
  </body>
</html>
```

```js
// my-coole-script.js

// request some data sending the members token if it's there
fetch('/some/data', {
  credentials: 'same-origin'
});
```