### PR TITLE
Members updates for third party use

### DIFF
--- a/packages/members/layer2/index.js
+++ b/packages/members/layer2/index.js
@@ -3,12 +3,14 @@ var layer1 = require('@tryghost/members-layer1');
 module.exports = function layer2(options) {
     var authUrl = `${options.membersUrl}/auth`;
     var gatewayUrl = `${options.membersUrl}/gateway`;
+    var container = options.container;
 
     var members = layer1({
-        gatewayUrl
+        gatewayUrl,
+        container
     });
 
-    var loadAuth = loadFrame(authUrl).then(function (frame) {
+    var loadAuth = loadFrame(authUrl, container).then(function (frame) {
         frame.style.position = 'fixed';
         frame.style.width = '100%';
         frame.style.height = '100%';

--- a/packages/members/theme-dropin/src/index.js
+++ b/packages/members/theme-dropin/src/index.js
@@ -2,8 +2,10 @@ const DomReady = require('domready');
 const GhostContentApi = require('@tryghost/content-api');
 const layer2 = require('@tryghost/members-layer2');
 
-function reload() {
-    window.location.reload();
+function reload(success) {
+    if (success) {
+        window.location.reload();
+    }
 }
 
 function show (el) {
@@ -24,8 +26,9 @@ DomReady(function () {
         const [tokenMatch, token] = query.match(/token=([a-zA-Z0-9-_]+.[a-zA-Z0-9-_]+.[a-zA-Z0-9-_]+)/) || [];
         if (tokenMatch) {
             return members.resetPassword({token})
-                .then(() => {
+                .then((success) => {
                     window.location.hash = '';
+                    return success;
                 })
                 .then(reload);
         }


### PR DESCRIPTION
These changes make it much easier for someone to work with layer2 directly.

Allows code like

```js
const members = layer2({
  membersUrl: 'https://ghost.egg/members',
  container: document.querySelector('.isolated-piece-of-DOM')
})

members.signin().then(success => {
  if (success) {
    // reload the page maybe
    // get a token and load some cool content?
  } else {
    // user exited not logged in - some analytics or smth
  }
});
```