### PR TITLE
🐛Allow empty separator for tags helper

### DIFF
--- a/packages/helpers/tags.js
+++ b/packages/helpers/tags.js
@@ -9,7 +9,7 @@ const visibility = require('./utils/visibility');
 
 module.exports = (data, options = {}) => {
     let output = '';
-    let separator = options.separator ? options.separator : ', ';
+    let separator = options.separator ? options.separator : '';
     let prefix = options.prefix ? options.prefix : '';
     let suffix = options.suffix ? options.suffix : '';
     let limit = options.limit ? parseInt(options.limit, 10) : undefined;
@@ -36,6 +36,7 @@ module.exports = (data, options = {}) => {
         // Check to see if options.fn returned a string, or something else
         if (_.isString(output[0])) {
             // If we're working with a string, do a simple join and string-concat
+            separator = separator || ', ';
             output = prefix + output.join(separator) + suffix;
         } else {
             // Else, operate on the array, and return an array


### PR DESCRIPTION
refs #29

- tags helper ignored empty separator option as it was initialised by default to `, `.
- Updated to only use default separator value as `, ` in case of string output