### PR TITLE
✨ Add `readingTime` helper to `@tryghost/helpers`

### DIFF
--- a/packages/helpers/lib/index.js
+++ b/packages/helpers/lib/index.js
@@ -1,7 +1,12 @@
 import * as visibility from './utils/visibility';
+import countWords from './utils/count-words';
+import countImages from './utils/count-images';
 
 export const utils = {
+    countImages,
+    countWords,
     visibility
 };
 
+export {default as readingTime} from './reading-time';
 export {default as tags} from './tags';

--- a/packages/helpers/lib/reading-time.js
+++ b/packages/helpers/lib/reading-time.js
@@ -1,0 +1,53 @@
+import countImages from './utils/count-images';
+import countWords from './utils/count-words';
+
+export function estimatedReadingTimeInMinutes({wordCount, imageCount}) {
+    const wordsPerMinute = 275;
+    const wordsPerSecond = wordsPerMinute / 60;
+    let readingTimeSeconds = wordCount / wordsPerSecond;
+
+    // add 12 seconds for the first image, 11 for the second, etc. limiting at 3
+    for (var i = 12; i > 12 - imageCount; i -= 1) {
+        readingTimeSeconds += Math.max(i, 3);
+    }
+
+    let readingTimeMinutes = Math.round(readingTimeSeconds / 60);
+
+    return readingTimeMinutes;
+}
+
+/**
+ * Reading Time Helper
+ *
+ * @param {object} post - the post with content that we want to generate a reading time for
+ * @param {object} options - output options
+ * @returns {string} estimated reading in minutes
+ */
+
+export default function (post, options = {}) {
+    const html = post.html;
+    const minuteStr = typeof options.minute === 'string' ? options.minute : '1 min read';
+    const minutesStr = typeof options.minutes === 'string' ? options.minutes : '% min read';
+
+    if (!html) {
+        return '';
+    }
+
+    let imageCount = countImages(html);
+    let wordCount = countWords(html);
+
+    if (post.feature_image) {
+        imageCount += 1;
+    }
+
+    const readingTimeInMinutes = estimatedReadingTimeInMinutes({wordCount, imageCount});
+    let readingTime = '';
+
+    if (readingTimeInMinutes <= 1) {
+        readingTime = minuteStr;
+    } else {
+        readingTime = minutesStr.replace('%', readingTimeInMinutes);
+    }
+
+    return readingTime;
+}

--- a/packages/helpers/lib/utils/count-images.js
+++ b/packages/helpers/lib/utils/count-images.js
@@ -1,0 +1,9 @@
+/**
+ * Image count Utility
+ * @param {string} html
+ * @returns {integer} image count
+ * @description Takes an HTML string and returns the number of images
+ **/
+export default function countImages(html) {
+    return (html.match(/<img(.|\n)*?>/g) || []).length;
+}

--- a/packages/helpers/lib/utils/count-words.js
+++ b/packages/helpers/lib/utils/count-words.js
@@ -1,0 +1,29 @@
+/**
+ * Word count Utility
+ * @param {string} text
+ * @returns {integer} word count
+ * @description Takes a string and returns the number of words after sanitizing any html
+ * This code is taken from https://github.com/sparksuite/simplemde-markdown-editor/blob/6abda7ab68cc20f4aca870eb243747951b90ab04/src/js/simplemde.js#L1054-L1067
+ * with extra diacritics character matching.
+ **/
+export default function countWords(text) {
+    text = text.replace(/<(.|\n)*?>/g, ' '); // strip any HTML tags
+
+    const pattern = /[a-zA-ZÀ-ÿ0-9_\u0392-\u03c9\u0410-\u04F9]+|[\u4E00-\u9FFF\u3400-\u4dbf\uf900-\ufaff\u3040-\u309f\uac00-\ud7af]+/g;
+    const match = text.match(pattern);
+    let count = 0;
+
+    if (match === null) {
+        return count;
+    }
+
+    for (var i = 0; i < match.length; i += 1) {
+        if (match[i].charCodeAt(0) >= 0x4e00) {
+            count += match[i].length;
+        } else {
+            count += 1;
+        }
+    }
+
+    return count;
+}

--- a/packages/helpers/test/reading-time.test.js
+++ b/packages/helpers/test/reading-time.test.js
@@ -1,0 +1,109 @@
+// Switch these lines once there are useful utils
+// const testUtils = require('./utils');
+require('./utils');
+
+const readingTimeHelper = require('../').readingTime;
+
+const almostOneMinute =
+    '<p>Ghost has a number of different user roles for your team</p>' +
+    '<h3 id="authors">Authors</h3><p>The base user level in Ghost is an author. Authors can write posts,' +
+    ' edit their own posts, and publish their own posts. Authors are <strong>trusted</strong> users. If you ' +
+    'don\'t trust users to be allowed to publish their own posts, you shouldn\'t invite them to Ghost admin.</p>' +
+    '<h3 id="editors">Editors</h3><p>Editors are the 2nd user level in Ghost. Editors can do everything that an' +
+    ' Author can do, but they can also edit and publish the posts of others - as well as their own. Editors can also invite new' +
+    ' authors to the site.</p><h3 id="administrators">Administrators</h3><p>The top user level in Ghost is Administrator.' +
+    ' Again, administrators can do everything that Authors and Editors can do, but they can also edit all site settings ' +
+    'and data, not just content. Additionally, administrators have full access to invite, manage or remove any other' +
+    ' user of the site.</p><h3 id="theowner">The Owner</h3><p>There is only ever one owner of a Ghost site. ' +
+    'The owner is a special user which has all the same permissions as an Administrator, but with two exceptions: ' +
+    'The Owner can never be deleted. And in some circumstances the owner will have access to additional special settings ' +
+    'if applicable — for example, billing details, if using Ghost(Pro).</p><hr><p>It\'s a good idea to ask all of your' +
+    ' users to fill out their user profiles, including bio and social links. These will populate rich structured data ' +
+    'for posts and generally create more opportunities for themes to fully populate their design.</p>';
+
+const almostOneAndAHalfMinute = almostOneMinute +
+    '<div>' +
+    '<p>Ghost has a number of different user roles for your team</p>' +
+    '<h3 id="authors">Authors</h3><p>The base user level in Ghost is an author. Authors can write posts,' +
+    ' edit their own posts, and publish their own posts. Authors are <strong>trusted</strong> users. If you ' +
+    'don\'t trust users to be allowed to publish their own posts, you shouldn\'t invite them to Ghost admin.</p>' +
+    '<h3 id="editors">Editors</h3><p>Editors are the 2nd user level in Ghost. Editors can do everything that an' +
+    ' Author can do, but they can also edit and publish the posts of others - as well as their own. Editors can also invite new' +
+    ' authors to the site.</p><h3 id="administrators">Administrators</h3><p>The top user level in Ghost is Administrator.' +
+    ' Again, administrators can do everything that Authors and Editors can do, but they can also edit all site settings ' +
+    'and data, not just content. Additionally, administrators have full access to invite</p>' +
+    '</div>';
+
+describe('readingTime helper', function () {
+    it('returns reading time for less than one minute text as one minute', function () {
+        const post = {html: almostOneMinute};
+        const result = readingTimeHelper(post);
+
+        result.should.equal('1 min read');
+    });
+
+    it('returns reading time for one minute text as one minute', function () {
+        const post = {
+            html: almostOneMinute +
+                    'This needed about twenty-five more words before passing the one minute reading time, ' +
+                    'since the word count was 250, and the average speed is 275.'
+        };
+        const result = readingTimeHelper(post);
+
+        result.should.equal('1 min read');
+    });
+
+    it('returns reading time for just under 1.5 minutes text as one minute', function () {
+        const post = {html: almostOneAndAHalfMinute};
+        const result = readingTimeHelper(post);
+
+        result.should.equal('1 min read');
+    });
+
+    it('adds time for feature image', function () {
+        const post = {
+            html: almostOneAndAHalfMinute,
+            feature_image: '/content/images/someimage.jpg'
+        };
+        const result = readingTimeHelper(post);
+
+        // The reading time for this HTML snippet would be 89 seconds without the image
+        // Adding the 12 additional seconds for the image results in a readng time of over 1.5 minutes, rounded to 2
+        result.should.equal('2 min read');
+    });
+
+    it('adds time for inline images', function () {
+        const post = {html: almostOneAndAHalfMinute + '<img src="test.png">'};
+        const result = readingTimeHelper(post);
+
+        // The reading time for this HTML snippet would be 89 seconds without the image
+        // Adding the 12 additional seconds for the image results in a readng time of over 1.5 minutes, rounded to 2
+        result.should.equal('2 min read');
+    });
+
+    it('accepts `minute` option', function () {
+        const post = {html: almostOneMinute};
+        const result = readingTimeHelper(post, {minute: 'minutes: 1'});
+
+        result.should.equal('minutes: 1');
+    });
+
+    it('accepts `minutes` option', function () {
+        const post = {html: almostOneAndAHalfMinute + '<img src="test.png">'};
+        const result = readingTimeHelper(post, {minutes: 'minutes: %'});
+
+        result.should.equal('minutes: 2');
+    });
+
+    it('returns blank string when input does not resemble a post ({html})', function () {
+        const post = {
+            author: {
+                name: 'abc 123',
+                slug: 'abc123'
+            }
+        };
+        const result = readingTimeHelper(post);
+
+        result.should.equal('');
+    });
+});


### PR DESCRIPTION
no issue
- adds `readingTime` helper, replicating `{{reading_time}}` helper output from Ghost
- adds `utils.countWords` which returns number of words in text/html
- adds `utils.countImages` which returns number of words in html

Changes from Ghost's helper:
- no use of `SafeString`, it's up to the consumer to wrap the output if necessary in whichever method is suitable for it's environment (react would be different to hbs for example)
- returns a blank string rather than `null` if the passed in object does not resemble a post so that the helper's return type is consistent