### PR TITLE
[admin-api] Add overridable `makeRequest` function

### DIFF
--- a/packages/admin-api/.eslintrc.js
+++ b/packages/admin-api/.eslintrc.js
@@ -3,4 +3,4 @@ module.exports = {
     extends: [
         'plugin:ghost/es',
     ]
-};
+}

--- a/packages/admin-api/test/admin-api.test.js
+++ b/packages/admin-api/test/admin-api.test.js
@@ -668,4 +668,19 @@ describe('GhostAdminAPI', function () {
             });
         });
     });
+
+    it('allows makeRequest override', function () {
+        const makeRequest = () => {
+            return Promise.resolve({
+                configuration: {
+                    test: true
+                }
+            });
+        };
+        const api = new GhostAdminAPI({host, version, key, makeRequest});
+
+        return api.configuration.read().then((data) => {
+            should.deepEqual(data, {test: true});
+        });
+    });
 });


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost-SDK/issues/48
- refactors internals to split url generation, authentication, and request handling into separate functions
- allow `makeRequest` to be passed in as an option to override the default axios based function