### PR TITLE
Added catch handler for Content & Admin SDK

### DIFF
--- a/packages/admin-api/lib/index.js
+++ b/packages/admin-api/lib/index.js
@@ -265,6 +265,29 @@ export default function GhostAdminAPI(options) {
             data,
             params,
             headers
+        }).catch((err) => {
+            /**
+             * @NOTE:
+             *
+             * If you are overriding `makeRequest`, we can't garantee that the returned format is the same, but
+             * we try to detect & return a proper error instance.
+             */
+            if (err.response && err.response.data && err.response.data.errors) {
+                const props = err.response.data.errors[0];
+                const toThrow = new Error(props.message);
+                const keys = Object.keys(props);
+
+                toThrow.name = props.type;
+
+                keys.forEach((key) => {
+                    toThrow[key] = props[key];
+                });
+
+                toThrow.response = err.response;
+                throw toThrow;
+            } else {
+                throw err;
+            }
         });
     }
 }

--- a/packages/content-api/lib/index.js
+++ b/packages/content-api/lib/index.js
@@ -96,6 +96,28 @@ export default function GhostContentAPI({url, host, ghostPath = 'ghost', version
                 return res.data[resourceType][0];
             }
             return Object.assign(res.data[resourceType], {meta: res.data.meta});
+        }).catch((err) => {
+            if (err.response && err.response.data && err.response.data.errors) {
+                const props = err.response.data.errors[0];
+                const toThrow = new Error(props.message);
+                const keys = Object.keys(props);
+
+                toThrow.name = props.type;
+
+                keys.forEach((key) => {
+                    toThrow[key] = props[key];
+                });
+
+                toThrow.response = err.response;
+
+                // @TODO: remove in 2.0. We have enhanced the error handling, but we don't want to break existing implementations.
+                toThrow.request = err.request;
+                toThrow.config = err.config;
+
+                throw toThrow;
+            } else {
+                throw err;
+            }
         });
     }
 }


### PR DESCRIPTION
closes #54

This adds a simple catch handler. I have not used Ignition because I did not see any advantages, only disadvantages:

- Ignition is quite fat and installs bunyan/logging, which we don't need
- Ignition error format != JSON API format
