### PR TITLE
[content-api] Deprecated `host` parameter in favour of `url`

### DIFF
--- a/packages/content-api/lib/index.js
+++ b/packages/content-api/lib/index.js
@@ -2,24 +2,34 @@ import axios from 'axios';
 
 const supportedVersions = ['v2'];
 
-export default function GhostContentAPI({host, ghostPath = 'ghost', version, key}) {
-    if (this instanceof GhostContentAPI) {
-        return GhostContentAPI({host, version, key});
+export default function GhostContentAPI({url, host, ghostPath = 'ghost', version, key}) {
+    // host parameter is deprecated
+    if (host) {
+        // eslint-disable-next-line
+        console.warn('GhostAdminAPI\'s `host` parameter is deprecated, please use `url` instead');
+        if (!url) {
+            url = host;
+        }
     }
+
+    if (this instanceof GhostContentAPI) {
+        return GhostContentAPI({url, version, key});
+    }
+
     if (!version) {
         throw new Error('GhostContentAPI Config Missing: @tryghost/content-api requires a "version" like "v2"');
     }
     if (!supportedVersions.includes(version)) {
         throw new Error('GhostContentAPI Config Invalid: @tryghost/content-api does not support the supplied version');
     }
-    if (!host) {
-        throw new Error('GhostContentAPI Config Missing: @tryghost/content-api requires a "host" like "https://site.com"');
+    if (!url) {
+        throw new Error('GhostContentAPI Config Missing: @tryghost/content-api requires a "url" like "https://site.com" or "https://site.com/blog"');
     }
-    if (!/https?:\/\//.test(host)) {
-        throw new Error('GhostContentAPI Config Invalid: @tryghost/content-api requires a "host" with a protocol like "https://site.com"');
+    if (!/https?:\/\//.test(url)) {
+        throw new Error('GhostContentAPI Config Invalid: @tryghost/content-api requires a "url" with a protocol like "https://site.com" or "https://site.com/blog"');
     }
-    if (host.endsWith('/')) {
-        throw new Error('GhostContentAPI Config Invalid: @tryghost/content-api requires a "host" without a trailing slash like "https://site.com"');
+    if (url.endsWith('/')) {
+        throw new Error('GhostContentAPI Config Invalid: @tryghost/content-api requires a "url" without a trailing slash like "https://site.com" or "https://site.com/blog"');
     }
     if (ghostPath.endsWith('/') || ghostPath.startsWith('/')) {
         throw new Error('GhostContentAPI Config Invalid: @tryghost/content-api requires a "ghostPath" without a leading or trailing slash like "ghost"');
@@ -69,7 +79,7 @@ export default function GhostContentAPI({host, ghostPath = 'ghost', version, key
             Authorization: `GhostMembers ${membersToken}`
         } : undefined;
 
-        return axios.get(`${host}/${ghostPath}/api/${version}/content/${resourceType}/${id ? id + '/' : ''}`, {
+        return axios.get(`${url}/${ghostPath}/api/${version}/content/${resourceType}/${id ? id + '/' : ''}`, {
             params: Object.assign({key}, params),
             paramsSerializer: (params) => {
                 return Object.keys(params).reduce((parts, key) => {

--- a/packages/content-api/test/content-api.test.js
+++ b/packages/content-api/test/content-api.test.js
@@ -9,15 +9,16 @@ const GhostContentApi = require('../');
 
 describe('GhostContentApi', function () {
     let server;
-    let host;
-    const version = 'v2';
-    const key = '0123456789abcdef0123456789';
+    const config = {
+        version: 'v2',
+        key: '0123456789abcdef0123456789'
+    };
 
     before(function (done) {
         server = http.createServer();
         server.on('listening', () => {
             const {address, port} = server.address();
-            host = `http://${address}:${port}`;
+            config.url = `http://${address}:${port}`;
             done();
         });
         server.on('request', (req, res) => {
@@ -61,7 +62,7 @@ describe('GhostContentApi', function () {
     });
 
     describe('new GhostContentApi', function () {
-        it('Requires a config object with host, version and key', function () {
+        it('Requires a config object with url, version and key', function () {
             try {
                 new GhostContentApi();
                 return should.fail();
@@ -70,34 +71,32 @@ describe('GhostContentApi', function () {
             }
 
             try {
-                new GhostContentApi({host, version});
+                new GhostContentApi({url: config.url, version: config.version});
                 return should.fail();
             } catch (err) {
                 //
             }
 
             try {
-                new GhostContentApi({version, key});
+                new GhostContentApi({version: config.version, key: config.key});
                 return should.fail();
             } catch (err) {
                 //
             }
 
             try {
-                new GhostContentApi({host, key});
+                new GhostContentApi({url: config.url, key: config.key});
                 return should.fail();
             } catch (err) {
                 //
             }
 
-            new GhostContentApi({host, version, key});
+            new GhostContentApi({host: config.url, key: config.key, version: config.version});
+            new GhostContentApi(config);
         });
 
         it('Returns an "api" object with posts,tags,authors&pages properties', function () {
-            const host = 'https://whatever.com';
-            const version = 'v2';
-            const key = '01234567890abcdef0123456789';
-            const api = new GhostContentApi({host, version, key});
+            const api = new GhostContentApi(config);
 
             should.exist(api.posts);
             should.exist(api.tags);
@@ -107,13 +106,13 @@ describe('GhostContentApi', function () {
 
         describe('api.posts', function () {
             it('has a browse method', function () {
-                const api = new GhostContentApi({host, version, key});
+                const api = new GhostContentApi(config);
                 should.equal(typeof api.posts.browse, 'function');
             });
 
             describe('api.posts.browse', function () {
                 it('makes a request to the posts resource, using correct version', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('url', ({pathname}) => {
                         should.equal(pathname, '/ghost/api/v2/content/posts/');
@@ -124,7 +123,7 @@ describe('GhostContentApi', function () {
                 });
 
                 it('supports the include option as an array', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('url', ({query}) => {
                         should.deepEqual(query.include, 'authors,tags');
@@ -135,7 +134,7 @@ describe('GhostContentApi', function () {
                 });
 
                 it('supports the include option as a string', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('url', ({query}) => {
                         should.equal(query.include, 'authors,tags');
@@ -146,7 +145,7 @@ describe('GhostContentApi', function () {
                 });
 
                 it('resolves with an array of the posts resources, and includes a meta property on the array', function () {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     return api.posts.browse().then((data) => {
                         should.equal(Array.isArray(data), true);
@@ -155,10 +154,10 @@ describe('GhostContentApi', function () {
                 });
 
                 it('correctly adds the api key to the query', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('url', ({query}) => {
-                        should.equal(query.key, key);
+                        should.equal(query.key, config.key);
                         done();
                     });
 
@@ -166,7 +165,7 @@ describe('GhostContentApi', function () {
                 });
 
                 it('correctly adds the members token to the query', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('headers', (headers) => {
                         should.equal(headers.authorization, 'GhostMembers token');
@@ -178,13 +177,13 @@ describe('GhostContentApi', function () {
             });
 
             it('has a read method', function () {
-                const api = new GhostContentApi({host, version, key});
+                const api = new GhostContentApi(config);
                 should.equal(typeof api.posts.read, 'function');
             });
 
             describe('api.posts.read', function () {
                 it('makes a request to the post resource, using correct version and id', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('url', ({pathname}) => {
                         should.equal(pathname, '/ghost/api/v2/content/posts/1/');
@@ -195,7 +194,7 @@ describe('GhostContentApi', function () {
                 });
 
                 it('makes a request to the post resource, using correct version and slug', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('url', ({pathname}) => {
                         should.equal(pathname, '/ghost/api/v2/content/posts/slug/booyar/');
@@ -206,7 +205,7 @@ describe('GhostContentApi', function () {
                 });
 
                 it('supports the include option as an array', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('url', ({query}) => {
                         should.deepEqual(query.include, 'authors,tags');
@@ -217,7 +216,7 @@ describe('GhostContentApi', function () {
                 });
 
                 it('supports the include option as a string', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('url', ({query}) => {
                         should.equal(query.include, 'authors,tags');
@@ -228,7 +227,7 @@ describe('GhostContentApi', function () {
                 });
 
                 it('resolves with the post resource', function () {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     return api.posts.read({id: '1'}).then((data) => {
                         should.equal(Array.isArray(data), false);
@@ -237,10 +236,10 @@ describe('GhostContentApi', function () {
                 });
 
                 it('correctly adds the api key to the query', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('url', ({query}) => {
-                        should.equal(query.key, key);
+                        should.equal(query.key, config.key);
                         done();
                     });
 
@@ -248,7 +247,7 @@ describe('GhostContentApi', function () {
                 });
 
                 it('correctly adds the members token to the query', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('headers', (headers) => {
                         should.equal(headers.authorization, 'GhostMembers token');
@@ -262,13 +261,13 @@ describe('GhostContentApi', function () {
 
         describe('api.authors', function () {
             it('has a browse method', function () {
-                const api = new GhostContentApi({host, version, key});
+                const api = new GhostContentApi(config);
                 should.equal(typeof api.authors.browse, 'function');
             });
 
             describe('api.authors.browse', function () {
                 it('makes a request to the authors resource, using correct version', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('url', ({pathname}) => {
                         should.equal(pathname, '/ghost/api/v2/content/authors/');
@@ -279,7 +278,7 @@ describe('GhostContentApi', function () {
                 });
 
                 it('supports the include option as an array', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('url', ({query}) => {
                         should.deepEqual(query.include, 'authors,tags');
@@ -290,7 +289,7 @@ describe('GhostContentApi', function () {
                 });
 
                 it('supports the include option as a string', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('url', ({query}) => {
                         should.equal(query.include, 'authors,tags');
@@ -301,7 +300,7 @@ describe('GhostContentApi', function () {
                 });
 
                 it('resolves with an array of the authors resources, and includes a meta property on the array', function () {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     return api.authors.browse().then((data) => {
                         should.equal(Array.isArray(data), true);
@@ -310,10 +309,10 @@ describe('GhostContentApi', function () {
                 });
 
                 it('correctly adds the api key to the query', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('url', ({query}) => {
-                        should.equal(query.key, key);
+                        should.equal(query.key, config.key);
                         done();
                     });
 
@@ -321,7 +320,7 @@ describe('GhostContentApi', function () {
                 });
 
                 it('correctly adds the members token to the query', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('headers', (headers) => {
                         should.equal(headers.authorization, 'GhostMembers token');
@@ -333,13 +332,13 @@ describe('GhostContentApi', function () {
             });
 
             it('has a read method', function () {
-                const api = new GhostContentApi({host, version, key});
+                const api = new GhostContentApi(config);
                 should.equal(typeof api.authors.read, 'function');
             });
 
             describe('api.authors.read', function () {
                 it('makes a request to the post resource, using correct version and id', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('url', ({pathname}) => {
                         should.equal(pathname, '/ghost/api/v2/content/authors/1/');
@@ -350,7 +349,7 @@ describe('GhostContentApi', function () {
                 });
 
                 it('makes a request to the user resource, using correct version and slug', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('url', ({pathname}) => {
                         should.equal(pathname, '/ghost/api/v2/content/authors/slug/booyar/');
@@ -361,7 +360,7 @@ describe('GhostContentApi', function () {
                 });
 
                 it('supports the include option as an array', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('url', ({query}) => {
                         should.deepEqual(query.include, 'authors,tags');
@@ -372,7 +371,7 @@ describe('GhostContentApi', function () {
                 });
 
                 it('supports the include option as a string', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('url', ({query}) => {
                         should.equal(query.include, 'authors,tags');
@@ -383,7 +382,7 @@ describe('GhostContentApi', function () {
                 });
 
                 it('resolves with the post resource', function () {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     return api.authors.read({id: '1'}).then((data) => {
                         should.equal(Array.isArray(data), false);
@@ -392,10 +391,10 @@ describe('GhostContentApi', function () {
                 });
 
                 it('correctly adds the api key to the query', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('url', ({query}) => {
-                        should.equal(query.key, key);
+                        should.equal(query.key, config.key);
                         done();
                     });
 
@@ -403,7 +402,7 @@ describe('GhostContentApi', function () {
                 });
 
                 it('correctly adds the members token to the query', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('headers', (headers) => {
                         should.equal(headers.authorization, 'GhostMembers token');
@@ -417,13 +416,13 @@ describe('GhostContentApi', function () {
 
         describe('api.tags', function () {
             it('has a browse method', function () {
-                const api = new GhostContentApi({host, version, key});
+                const api = new GhostContentApi(config);
                 should.equal(typeof api.tags.browse, 'function');
             });
 
             describe('api.tags.browse', function () {
                 it('makes a request to the tags resource, using correct version', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('url', ({pathname}) => {
                         should.equal(pathname, '/ghost/api/v2/content/tags/');
@@ -434,7 +433,7 @@ describe('GhostContentApi', function () {
                 });
 
                 it('supports the include option as an array', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('url', ({query}) => {
                         should.deepEqual(query.include, 'authors,tags');
@@ -445,7 +444,7 @@ describe('GhostContentApi', function () {
                 });
 
                 it('supports the include option as a string', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('url', ({query}) => {
                         should.equal(query.include, 'authors,tags');
@@ -456,7 +455,7 @@ describe('GhostContentApi', function () {
                 });
 
                 it('resolves with an array of the tags resources, and includes a meta property on the array', function () {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     return api.tags.browse().then((data) => {
                         should.equal(Array.isArray(data), true);
@@ -465,10 +464,10 @@ describe('GhostContentApi', function () {
                 });
 
                 it('correctly adds the api key to the query', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('url', ({query}) => {
-                        should.equal(query.key, key);
+                        should.equal(query.key, config.key);
                         done();
                     });
 
@@ -476,7 +475,7 @@ describe('GhostContentApi', function () {
                 });
 
                 it('correctly adds the members token to the query', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('headers', (headers) => {
                         should.equal(headers.authorization, 'GhostMembers token');
@@ -488,13 +487,13 @@ describe('GhostContentApi', function () {
             });
 
             it('has a read method', function () {
-                const api = new GhostContentApi({host, version, key});
+                const api = new GhostContentApi(config);
                 should.equal(typeof api.tags.read, 'function');
             });
 
             describe('api.tags.read', function () {
                 it('makes a request to the post resource, using correct version and id', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('url', ({pathname}) => {
                         should.equal(pathname, '/ghost/api/v2/content/tags/1/');
@@ -505,7 +504,7 @@ describe('GhostContentApi', function () {
                 });
 
                 it('makes a request to the tag resource, using correct version and slug', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('url', ({pathname}) => {
                         should.equal(pathname, '/ghost/api/v2/content/tags/slug/booyar/');
@@ -516,7 +515,7 @@ describe('GhostContentApi', function () {
                 });
 
                 it('supports the include option as an array', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('url', ({query}) => {
                         should.deepEqual(query.include, 'authors,tags');
@@ -527,7 +526,7 @@ describe('GhostContentApi', function () {
                 });
 
                 it('supports the include option as a string', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('url', ({query}) => {
                         should.equal(query.include, 'authors,tags');
@@ -538,7 +537,7 @@ describe('GhostContentApi', function () {
                 });
 
                 it('resolves with the tags resource', function () {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     return api.tags.read({id: '1'}).then((data) => {
                         should.equal(Array.isArray(data), false);
@@ -547,10 +546,10 @@ describe('GhostContentApi', function () {
                 });
 
                 it('correctly adds the api key to the query', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('url', ({query}) => {
-                        should.equal(query.key, key);
+                        should.equal(query.key, config.key);
                         done();
                     });
 
@@ -558,7 +557,7 @@ describe('GhostContentApi', function () {
                 });
 
                 it('correctly adds the members token to the query', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('headers', (headers) => {
                         should.equal(headers.authorization, 'GhostMembers token');
@@ -572,13 +571,13 @@ describe('GhostContentApi', function () {
 
         describe('api.pages', function () {
             it('has a browse method', function () {
-                const api = new GhostContentApi({host, version, key});
+                const api = new GhostContentApi(config);
                 should.equal(typeof api.pages.browse, 'function');
             });
 
             describe('api.pages.browse', function () {
                 it('makes a request to the pages resource, using correct version', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('url', ({pathname}) => {
                         should.equal(pathname, '/ghost/api/v2/content/pages/');
@@ -589,7 +588,7 @@ describe('GhostContentApi', function () {
                 });
 
                 it('supports the include option as an array', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('url', ({query}) => {
                         should.deepEqual(query.include, 'authors,tags');
@@ -600,7 +599,7 @@ describe('GhostContentApi', function () {
                 });
 
                 it('supports the include option as a string', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('url', ({query}) => {
                         should.equal(query.include, 'authors,tags');
@@ -611,7 +610,7 @@ describe('GhostContentApi', function () {
                 });
 
                 it('resolves with an array of the pages resources, and includes a meta property on the array', function () {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     return api.pages.browse().then((data) => {
                         should.equal(Array.isArray(data), true);
@@ -620,10 +619,10 @@ describe('GhostContentApi', function () {
                 });
 
                 it('correctly adds the api key to the query', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('url', ({query}) => {
-                        should.equal(query.key, key);
+                        should.equal(query.key, config.key);
                         done();
                     });
 
@@ -631,7 +630,7 @@ describe('GhostContentApi', function () {
                 });
 
                 it('correctly adds the members token to the query', function (done) {
-                    const api = new GhostContentApi({host, version, key});
+                    const api = new GhostContentApi(config);
 
                     server.once('headers', (headers) => {
                         should.equal(headers.authorization, 'GhostMembers token');


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost-SDK/issues/46
- display a deprecation warning if `host` parameter is used instead of `url`
- update error messages and include a subdirectory example