### PR TITLE
Fixed `should have a unique "key" prop` error when using <Tags> component

### DIFF
--- a/packages/helpers-gatsby/src/Tags.js
+++ b/packages/helpers-gatsby/src/Tags.js
@@ -36,37 +36,56 @@ const Tags = (props) => {
         visibility: props.visibility,
     }
 
-    if (props.separator) {
-        opts.separator = React.isValidElement(props.separator) ? props.separator :
-            <><span className={props.separatorClasses}>{props.separator}</span></>
+    let keyIndex = 0
+    const generateKey = (pre) => {
+        keyIndex = keyIndex + 1
+        return `${pre}_${keyIndex}`
     }
+
+    Object.defineProperty(opts, 'separator', {
+        get() {
+            if (props.separator && React.isValidElement(props.separator)) {
+                return (
+                    <React.Fragment key={generateKey('separator')}>
+                        {props.separator}
+                    </React.Fragment>
+                )
+            } else {
+                return (
+                    <span className={props.separatorClasses} key={generateKey('separator')}>
+                        {props.separator}
+                    </span>
+                )
+            }
+        },
+    })
 
     if (props.prefix) {
         opts.prefix = React.isValidElement(props.prefix) ? props.prefix :
-            <><span className={props.prefixClasses}>{props.prefix}</span></>
+            <span className={props.prefixClasses} key="prefix">{props.prefix}</span>
     }
 
     if (props.suffix) {
         opts.suffix = React.isValidElement(props.suffix) ? props.suffix :
-            <><span className={props.suffixClasses}>{props.suffix}</span></>
+            <span className={props.suffixClasses} key="suffix">{props.suffix}</span>
     }
 
     opts.fn = function process(tag) {
         let tagLink = props.permalink
         tagLink = tagLink.replace(/:slug/, tag.slug) || `/${tag.slug}/`
 
-        return props.autolink ?
-            <>
-                <span className={props.classes} key={tag.slug}>
-                    <Link to={tagLink} className={props.linkClasses}>{tag.name}</Link>
-                </span>
-            </> :
-            <><span className={props.classes} key={tag.slug}>{tag.name}</span></>
+        return props.autolink ? (
+            <span className={props.classes} key={tag.slug}>
+                <Link to={tagLink} className={props.linkClasses}>
+                    {tag.name}
+                </Link>
+            </span>
+        ) : (
+            <span className={props.classes} key={tag.slug}>{tag.name}</span>
+        )
     }
 
-    return (
-        tagsHelper(props.post, opts)
-    )
+    return tagsHelper(props.post, opts)
 }
 
 Tags.defaultProps = {


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost-SDK/issues/42

Why the error was occurring:
- the `tags(data, opts)` helper from @tryghost/helpers returns an array
- our use of the helper with `<></>` around the output of each option resulted in an array of `<React.Fragment>` elements with no keys set
- we return the array of react fragment elements, React maps over this and sees that each top-level element in the list has no unique key

How it was fixed:
- return `<span>` elements directly rather than wrapping in fragments so top-level elements have a key
- define `opts.separator` as a getter so that a unique key can be generated each time it is accessed by the `tags()` helper