### PR TITLE
admin-api .read method compatibility with content-api's one

### DIFF
--- a/packages/admin-api/lib/index.js
+++ b/packages/admin-api/lib/index.js
@@ -136,7 +136,18 @@ module.exports = function GhostAdminAPI(options) {
                 return Promise.reject(new Error('Must include either data.id or data.slug or data.email'));
             }
 
-            const urlParams = data;
+            const urlParams = {
+                id: data.id,
+                slug: data.slug,
+                email: data.email
+            };
+
+            delete data.id;
+            delete data.slug;
+            delete data.email;
+
+            queryParams = Object.assign({}, queryParams, data);
+
             return makeResourceRequest(resourceType, queryParams, {}, 'GET', urlParams);
         }
 

--- a/packages/admin-api/test/admin-api.test.js
+++ b/packages/admin-api/test/admin-api.test.js
@@ -290,6 +290,28 @@ describe('GhostAdminAPI', function () {
                     api[resource].read({id: '1'}, {include: 'authors,tags'});
                 });
 
+                it('can include fields as strings', function (done) {
+                    const api = new GhostAdminAPI(config);
+
+                    server.once('url', ({query}) => {
+                        should.equal(query.fields, 'id,slug');
+                        done();
+                    });
+
+                    api[resource].read({id: 1, fields: 'id,slug'});
+                });
+
+                it('can include fields as array', function (done) {
+                    const api = new GhostAdminAPI(config);
+
+                    server.once('url', ({query}) => {
+                        should.deepEqual(query.fields, 'id,slug');
+                        done();
+                    });
+
+                    api[resource].read({id: 1, fields: ['id', 'slug']});
+                });
+
                 it('can include fields as strings in second parameter', function (done) {
                     const api = new GhostAdminAPI(config);
 

--- a/packages/admin-api/test/admin-api.test.js
+++ b/packages/admin-api/test/admin-api.test.js
@@ -334,6 +334,20 @@ describe('GhostAdminAPI', function () {
                     api[resource].read({id: 1}, {fields: ['id', 'slug']});
                 });
 
+                it('can combine multiple properties in first parameter', function (done) {
+                    const api = new GhostAdminAPI(config);
+
+                    server.once('url', ({pathname, query}) => {
+                        should.equal(pathname, `/ghost/api/v2/admin/${resource}/slug/kevin/`);
+
+                        should.deepEqual(query.fields, 'id,slug');
+                        should.deepEqual(query.include, 'author,tag');
+                        done();
+                    });
+
+                    api[resource].read({slug: 'kevin', fields: ['id', 'slug'], include: 'author,tag'});
+                });
+
                 it('resolves with data', function () {
                     const api = new GhostAdminAPI(config);
 

--- a/packages/admin-api/test/admin-api.test.js
+++ b/packages/admin-api/test/admin-api.test.js
@@ -290,6 +290,28 @@ describe('GhostAdminAPI', function () {
                     api[resource].read({id: '1'}, {include: 'authors,tags'});
                 });
 
+                it('can include fields as strings in second parameter', function (done) {
+                    const api = new GhostAdminAPI(config);
+
+                    server.once('url', ({query}) => {
+                        should.equal(query.fields, 'id,slug');
+                        done();
+                    });
+
+                    api[resource].read({id: 1}, {fields: 'id,slug'});
+                });
+
+                it('can include fields as array in second parameter', function (done) {
+                    const api = new GhostAdminAPI(config);
+
+                    server.once('url', ({query}) => {
+                        should.deepEqual(query.fields, 'id,slug');
+                        done();
+                    });
+
+                    api[resource].read({id: 1}, {fields: ['id', 'slug']});
+                });
+
                 it('resolves with data', function () {
                     const api = new GhostAdminAPI(config);
 

--- a/packages/admin-api/test/admin-api.test.js
+++ b/packages/admin-api/test/admin-api.test.js
@@ -192,6 +192,28 @@ describe('GhostAdminAPI', function () {
                     api[resource].browse({include: ['authors', 'tags']});
                 });
 
+                it('can include fields as strings', function (done) {
+                    const api = new GhostAdminAPI(config);
+
+                    server.once('url', ({query}) => {
+                        should.equal(query.fields, 'id,slug');
+                        done();
+                    });
+
+                    api[resource].browse({fields: 'id,slug'});
+                });
+
+                it('can include fields as array', function (done) {
+                    const api = new GhostAdminAPI(config);
+
+                    server.once('url', ({query}) => {
+                        should.deepEqual(query.fields, 'id,slug');
+                        done();
+                    });
+
+                    api[resource].browse({fields: ['id', 'slug']});
+                });
+
                 it('can include relations as strings', function (done) {
                     const api = new GhostAdminAPI(config);
 

--- a/packages/content-api/test/content-api.test.js
+++ b/packages/content-api/test/content-api.test.js
@@ -253,6 +253,17 @@ describe('GhostContentApi', function () {
                     api.posts.read({id: '1'}, {include: 'authors,tags'});
                 });
 
+                it('supports the include option in first parameter', function (done) {
+                    const api = new GhostContentApi(config);
+
+                    server.once('url', ({query}) => {
+                        should.equal(query.include, 'authors,tags');
+                        done();
+                    });
+
+                    api.posts.read({id: '1', include: 'authors,tags'});
+                });
+
                 it('resolves with the post resource', function () {
                     const api = new GhostContentApi(config);
 
@@ -434,7 +445,18 @@ describe('GhostContentApi', function () {
                     api.authors.read({id: '1'}, {include: 'authors,tags'});
                 });
 
-                it('resolves with the post resource', function () {
+                it('supports the include option in first parameter', function (done) {
+                    const api = new GhostContentApi(config);
+
+                    server.once('url', ({query}) => {
+                        should.equal(query.include, 'authors,tags');
+                        done();
+                    });
+
+                    api.authors.read({id: '1', include: 'authors,tags'});
+                });
+
+                it('resolves with the author resource', function () {
                     const api = new GhostContentApi(config);
 
                     return api.authors.read({id: '1'}).then((data) => {
@@ -587,6 +609,17 @@ describe('GhostContentApi', function () {
                     });
 
                     api.tags.read({id: '1'}, {include: 'authors,tags'});
+                });
+
+                it('supports the include option in first parameter', function (done) {
+                    const api = new GhostContentApi(config);
+
+                    server.once('url', ({query}) => {
+                        should.equal(query.include, 'authors,tags');
+                        done();
+                    });
+
+                    api.tags.read({id: '1', include: 'authors,tags'});
                 });
 
                 it('resolves with the tags resource', function () {

--- a/packages/content-api/test/content-api.test.js
+++ b/packages/content-api/test/content-api.test.js
@@ -723,7 +723,7 @@ describe('GhostContentApi', function () {
                         done();
                     });
 
-                    api.posts.browse({id: 1}, 'token');
+                    api.pages.browse({id: 1}, 'token');
                 });
             });
         });


### PR DESCRIPTION
closes #94

done:
- [x] coverage for existing cases
- [x] accepting query parameters (`include`, fields) as a single parameter in .read method along with id/slug/email

couple more things to come:
- [x] cover using a combination of parameters include+fields
- [x] cover `fields` parameter usage in content-api sdk (it's not clear how it works from the test suite)