### PR TITLE
Removed hardcoded api version and type

### DIFF
--- a/packages/url-utils/lib/index.js
+++ b/packages/url-utils/lib/index.js
@@ -276,7 +276,7 @@ module.exports = class UrlUtils {
             }
         } else if (context === 'api') {
             urlPath = this.getAdminUrl() || this.getSiteUrl();
-            let apiPath = this.getApiPath({version: 'v0.1', type: 'content'});
+            let apiPath = this.getApiPath();
             // CASE: with or without protocol? If your blog url (or admin url) is configured to http, it's still possible that e.g. nginx allows both https+http.
             // So it depends how you serve your blog. The main focus here is to avoid cors problems.
             // @TODO: rename cors


### PR DESCRIPTION
no-issue

We should be respecting the default api version and type, which may be
passed in by the consumer of this module.
