### PR TITLE
Added default of reading_time when passed to readingtime helper

### DIFF
--- a/packages/helpers/lib/reading-time.js
+++ b/packages/helpers/lib/reading-time.js
@@ -25,7 +25,7 @@ export default function (post, options = {}) {
         imageCount += 1;
     }
 
-    const time = readingMinutes(post.html, imageCount);
+    const time = post.reading_time || readingMinutes(post.html, imageCount);
     let readingTime = '';
 
     if (time <= 1) {

--- a/packages/helpers/test/reading-time.test.js
+++ b/packages/helpers/test/reading-time.test.js
@@ -106,4 +106,14 @@ describe('readingTime helper', function () {
 
         result.should.equal('');
     });
+
+    it('accepts and uses pre-filled reading_time', function () {
+        const post = {
+            html: almostOneAndAHalfMinute + '<img src="test.png">',
+            reading_time: 200
+        };
+        const result = readingTimeHelper(post);
+
+        result.should.equal('200 min read');
+    });
 });


### PR DESCRIPTION
no issue

- As the property becomes a part of Content API v3 response in posts and pages it should become a default value and use calculation of reading time as a fallback
