### PR TITLE
🐛 Fixed reading_time output when precalculated property exists

### DIFF
--- a/packages/helpers/lib/reading-time.js
+++ b/packages/helpers/lib/reading-time.js
@@ -11,11 +11,10 @@ import readingMinutes from './utils/reading-minutes';
  */
 
 export default function (post, options = {}) {
-    const html = post.html;
     const minuteStr = typeof options.minute === 'string' ? options.minute : '1 min read';
     const minutesStr = typeof options.minutes === 'string' ? options.minutes : '% min read';
 
-    if (!html) {
+    if (!post.html && !post.reading_time) {
         return '';
     }
 

--- a/packages/helpers/test/reading-time.test.js
+++ b/packages/helpers/test/reading-time.test.js
@@ -116,4 +116,13 @@ describe('readingTime helper', function () {
 
         result.should.equal('200 min read');
     });
+
+    it('accepts and uses pre-filled reading_time even when html is not present', function () {
+        const post = {
+            reading_time: 200
+        };
+        const result = readingTimeHelper(post);
+
+        result.should.equal('200 min read');
+    });
 });


### PR DESCRIPTION
When post doesn't have `html` set but has calculated `reading_time` it should still output a valid reading time string. The use case happens for members/paid posts
