### PR TITLE
🐛 Fixed tests that check for errors

### DIFF
--- a/packages/admin-api/lib/index.js
+++ b/packages/admin-api/lib/index.js
@@ -60,6 +60,9 @@ module.exports = function GhostAdminAPI(options) {
     if (config.ghostPath.endsWith('/') || config.ghostPath.startsWith('/')) {
         throw new Error('GhostAdminAPI Config Invalid: @tryghost/admin-api requires a "ghostPath" without a leading or trailing slash like "ghost"');
     }
+    if (!config.key) {
+        throw new Error('GhostAdminAPI Config Invalid: @tryghost/admin-api requires a "key" to be supplied');
+    }
     if (config.key && !/[0-9a-f]{24}:[0-9a-f]{64}/.test(config.key)) {
         throw new Error('GhostAdminAPI Config Invalid: @tryghost/admin-api requires a "key" in following format {A}:{B}, where A is 24 hex characters and B is 64 hex characters');
     }

--- a/packages/admin-api/test/admin-api.test.js
+++ b/packages/admin-api/test/admin-api.test.js
@@ -125,45 +125,47 @@ describe('GhostAdminAPI', function () {
         });
 
         it('Requires a config object with host, version and key', function () {
-            try {
-                new GhostAdminAPI();
-                return should.fail();
-            } catch (err) {
-                //
-            }
+            should.throws(
+                () => new GhostAdminAPI(),
+                Error,
+                'Missing config object'
+            );
+            should.throws(
+                () => new GhostAdminAPI({url: config.url, version: config.version}),
+                Error,
+                'Missing config.key property'
+            );
 
-            try {
-                new GhostAdminAPI({url: config.url, version: config.version});
-                return should.fail();
-            } catch (err) {
-                //
-            }
+            should.throws(
+                () => new GhostAdminAPI({version: config.version, key: config.key}),
+                Error,
+                'Missing config.url property'
+            );
 
-            try {
-                new GhostAdminAPI({version: config.version, key: config.key});
-                return should.fail();
-            } catch (err) {
-                //
-            }
+            should.throws(
+                () => new GhostAdminAPI({url: config.url, key: config.key}),
+                Error,
+                'Missing config.version property'
+            );
 
-            try {
-                new GhostAdminAPI({url: config.url, key: config.key});
-                return should.fail();
-            } catch (err) {
-                //
-            }
-
-            new GhostAdminAPI({url: config.url, version: config.version, key: config.key});
-            new GhostAdminAPI(config);
+            should.doesNotThrow(
+                () => new GhostAdminAPI({url: config.url, version: config.version, key: config.key}),
+                Error,
+                'Correct config properties'
+            );
+            should.doesNotThrow(
+                () => new GhostAdminAPI(config),
+                Error,
+                'Correct config object'
+            );
         });
 
-        it('Requires correct key format in config object', function (){
-            try {
-                new GhostAdminAPI({key: 'badkey', config: config.url, version: config.version});
-                return should.fail();
-            } catch (err) {
-                //
-            }
+        it('Requires correct key format in config object', function () {
+            should.throws(
+                () => new GhostAdminAPI({key: 'badkey', url: config.url, version: config.version}),
+                Error,
+                'Invalid config.key property'
+            );
         });
 
         ['posts', 'pages', 'tags'].forEach((resource) => {


### PR DESCRIPTION
closes: #149

- (AdminAPI) Added condition for missing config.key value
- (AdminAPI) Updated tests to use should.throw() properly; ran into a
situation where tests were not failing with should.fail() syntax

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
