### PR TITLE
Switched to Renovate's LTS support policy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   ],
   "travis": { "enabled": true },
   "node": {
-    "supportPolicy": ["lts_active"]
+    "supportPolicy": ["lts"]
    },
   "ignorePaths": ["packages/members"],
   "packageRules": [


### PR DESCRIPTION
no issue

- we only support LTS versions and not active ones