### PR TITLE
Autolink Fix

### DIFF
--- a/packages/helpers-gatsby/lib/Tags.js
+++ b/packages/helpers-gatsby/lib/Tags.js
@@ -87,7 +87,7 @@ var Tags = function Tags(props) {
 
   opts.fn = function process(tag) {
     var tagLink = props.permalink;
-    tagLink = tagLink.replace(/:slug/, tag.slug) || "/".concat(tag.slug, "/");
+    tagLink = tagLink.replace(/:slug/, tag.slug) || "/tag/".concat(tag.slug, "/");
     return props.autolink ? _react["default"].createElement("span", {
       className: props.classes,
       key: tag.slug
@@ -111,7 +111,7 @@ Tags.defaultProps = {
   prefixClasses: "",
   suffixClasses: "",
   linkClasses: "",
-  permalink: "/:slug/",
+  permalink: "/tag/:slug/",
   autolink: true
 };
 Tags.propTypes = {


### PR DESCRIPTION
no issue
🐛 Fixed Tag autolink where it wasn't working due to incompletion of URL due to `:slug` was missing prefix `/tag/`.

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
