### PR TITLE
Updated Axios version to 0.19.2 (#208)

### DIFF
--- a/packages/content-api/package.json
+++ b/packages/content-api/package.json
@@ -46,7 +46,7 @@
     "sinon": "7.4.1"
   },
   "dependencies": {
-    "axios": "0.19.1",
+    "axios": "0.19.2",
     "ghost-ignition": "^3.0.0"
   }
 }


### PR DESCRIPTION
Corrects a bug with Axios XSS prevention (present in version 0.19.1, fixed on 0.19.2) where any request containing the word "javascript" on the URL would instantly fail.