### PR TITLE
fixed issue  https://github.com/TryGhost/Ghost-SDK/issues/150#issue-4…

### DIFF
--- a/packages/admin-api/lib/index.js
+++ b/packages/admin-api/lib/index.js
@@ -56,7 +56,7 @@ module.exports = function GhostAdminAPI(options) {
         throw new Error('GhostAdminAPI Config Invalid: @tryghost/admin-api requires a "url" with a protocol like "https://site.com" or "https://site.com/blog"');
     }
     if (config.url.endsWith('/')) {
-        throw new Error('GhostAdminAPI Config Invalid: @tryghost/admin-api requires a "url" without a trailing slash like "https://site.com" or "https://site.com/blog"');
+        throw new Error(`The Url: ${config.url} you passed was invalide, GhostAdminAPI Config Invalid: @tryghost/admin-api requires a "url" without a trailing slash like "https://site.com" or "https://site.com/blog"`);
     }
     if (config.ghostPath.endsWith('/') || config.ghostPath.startsWith('/')) {
         throw new Error('GhostAdminAPI Config Invalid: @tryghost/admin-api requires a "ghostPath" without a leading or trailing slash like "ghost"');


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!
when a url with a trailing slash is passed to the admin api, it shows an error, to make it easy for user to debug it, displaying the url that was passed would be handful..
i added the url that was passed to the error message 

- [ ] There's a clear use-case for this code change
- [ ] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
