### PR TITLE
Added support for stripe_customer_id to members input

### DIFF
--- a/packages/admin-api-schema/lib/canary/members.json
+++ b/packages/admin-api-schema/lib/canary/members.json
@@ -33,6 +33,9 @@
         "comped": {
           "type": "boolean"
         },
+        "stripe_customer_id": {
+          "type": "string"
+        },
         "id": {
           "strip": true
         },


### PR DESCRIPTION
no-issue

The members api allows adding a member with the `stripe_customer_id` property, but the schema does not allow us to pass it.