### PR TITLE
🐛 Fixed Brasilia timezone according to the Senate bulletin of April 25, 2019

### DIFF
--- a/packages/timezone-data/lib/index.js
+++ b/packages/timezone-data/lib/index.js
@@ -61,7 +61,7 @@ export default [
     },
     {
         name: 'America/Halifax',
-        label: '(GMT -4:00) Atlantic Time (Canada); Brasilia, Greenland'
+        label: '(GMT -4:00) Atlantic Time (Canada); Greenland'
     },
     {
         name: 'America/Santiago',
@@ -73,7 +73,7 @@ export default [
     },
     {
         name: 'America/Argentina/Buenos_Aires',
-        label: '(GMT -3:00) Buenos Aires, Georgetown'
+        label: '(GMT -3:00) Buenos Aires, Brasilia, Georgetown'
     },
     {
         name: 'America/Noronha',


### PR DESCRIPTION
Closes [#12346](https://github.com/TryGhost/Ghost/issues/12346)

According to the Brasil Senate bulletin of April 25, 2019, There will be no further clock changes in Brazil in 2019 so changed the Brasilian timezone to GMT -3:00.


https://www.timeanddate.com/news/time/brazil-scraps-dst.html